### PR TITLE
fix: add line breaks in self-hosted overview

### DIFF
--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -19,6 +19,7 @@ Note that choosing whether to send errors or not will become mandatory beginning
 If you opt-in to it, self-hosted Sentry will periodically communicate with a remote beacon server. This is utilized for a couple of things, primarily:
 - Getting information about the current version of Sentry
 - Retrieving important system notices
+
 The remote server is operated by the Sentry team (sentry.io), and the information reported follows the company's [privacy policy](https://sentry.io/privacy/).
 
 The following information is reported:
@@ -27,6 +28,7 @@ The following information is reported:
 3. A technical contact email if opted in to sending contact info (system.admin-email)
 4. General anonymous statistics on the data pattern (such as the number of users and volume of errors)
 5. Names and version of the installed Python modules
+
 Note: The contact email is utilized for security announcements, and will never be used outside of such. You can change your opt in/out settings for sending contact info at any time in the settings of the admin panel.
 
 The data reported is minimal and it greatly helps the development team behind Sentry. With that said, you can disable the beacon with the following setting:


### PR DESCRIPTION
Without line breaks, the following paragraph is merged into the last list item.